### PR TITLE
Fix compilation error part 1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,9 @@ if test x$with_libgsf != xno; then
     PKG_CHECK_MODULES(GSF, libgsf-1 >= $LIBGSF_REQ, have_gsf=yes, have_gsf=no)
 fi
 if test "x$have_gsf" = "xyes"; then
+    PKG_CHECK_MODULES(GSF_1_14_24, libgsf-1 >= 1.14.24,
+		      AC_DEFINE(HAVE_GSF_1_14_24,1,[Define to 1 if you have libgsf >= 1.14.24]),
+		      have_gsf_1_14_24=no)
     PKG_CHECK_MODULES(GSF_1_14_26, libgsf-1 >= 1.14.26,
 		      AC_DEFINE(HAVE_GSF_1_14_26,1,[Define to 1 if you have libgsf >= 1.14.26]),
 		      have_gsf_1_14_26=no)

--- a/src/dialogs/gnome-cmd-options-dialog.cc
+++ b/src/dialogs/gnome-cmd-options-dialog.cc
@@ -269,7 +269,14 @@ static void on_date_format_update (GtkEditable *editable, GtkWidget *options_dia
 
     char s[256];
     time_t t = time (NULL);
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
     strftime (s, sizeof(s), locale_format, localtime (&t));
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     gchar *utf8_str = g_locale_to_utf8 (s, -1, NULL, NULL, NULL);
 
     gtk_label_set_text (GTK_LABEL (test_label), utf8_str);

--- a/src/dialogs/gnome-cmd-search-dialog.cc
+++ b/src/dialogs/gnome-cmd-search-dialog.cc
@@ -1022,6 +1022,9 @@ void GnomeCmdSearchDialog::Private::on_dialog_response(GtkDialog *window, int re
                 g_free (fpath);
                 g_free (dpath);
             }
+#if defined (__GNUC__)
+            __attribute__ ((fallthrough));
+#endif
 
         case GTK_RESPONSE_NONE:
         case GTK_RESPONSE_DELETE_EVENT:

--- a/src/dict.h
+++ b/src/dict.h
@@ -144,13 +144,13 @@ inline void load_data(DICT<KEY,VAL> &dict, void *a, unsigned n)
     if (!a)
         return;
 
-    typedef struct
+    struct TUPLE
     {
         KEY key;
         VAL value;
-    } TUPLE;
+    };
 
-    TUPLE *t = static_cast<TUPLE *>(a);
+    struct TUPLE *t = static_cast<struct TUPLE *>(a);
 
     for (unsigned i=0; i<n; ++i, ++t)
          dict.add(t->key,t->value);
@@ -163,13 +163,13 @@ inline void load_data(DICT<KEY,std::string> &dict, void *a, unsigned n)
     if (!a)
         return;
 
-    typedef struct
+    struct TUPLE
     {
         KEY  key;
         char *value;
-    } TUPLE;
+    };
 
-    TUPLE *t = static_cast<TUPLE *>(a);
+    struct TUPLE *t = static_cast<struct TUPLE *>(a);
 
     for (unsigned i=0; i<n; ++i, ++t)
          dict.add(t->key,t->value);
@@ -182,13 +182,13 @@ inline void load_data(DICT<std::string,VAL> &dict, void *a, unsigned n)
     if (!a)
         return;
 
-    typedef struct
+    struct TUPLE
     {
         char *key;
         VAL  value;
-    } TUPLE;
+    };
 
-    TUPLE *t = static_cast<TUPLE *>(a);
+    struct TUPLE *t = static_cast<struct TUPLE *>(a);
 
     for (unsigned i=0; i<n; ++i, ++t)
          dict.add(t->key,t->value);
@@ -200,13 +200,13 @@ inline void load_data(DICT<std::string,std::string> &dict, void *a, unsigned n)
     if (!a)
         return;
 
-    typedef struct
+    struct TUPLE
     {
         char *key;
         char *value;
-    } TUPLE;
+    };
 
-    TUPLE *t = static_cast<TUPLE *>(a);
+    struct TUPLE *t = static_cast<struct TUPLE *>(a);
 
     for (unsigned i=0; i<n; ++i, ++t)
          dict.add(t->key,t->value);

--- a/src/tags/gnome-cmd-tags-doc.cc
+++ b/src/tags/gnome-cmd-tags-doc.cc
@@ -61,6 +61,10 @@ static DICT<GnomeCmdTag> gsf_tags(TAG_NONE);
 
 inline const gchar *lid2lang (guint lid)
 {
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-enum"
+#endif
     switch (lid)
     {
         case 0x0400:
@@ -183,6 +187,9 @@ inline const gchar *lid2lang (guint lid)
         default:
             return NULL;
     }
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 
@@ -204,6 +211,10 @@ static void process_metadata(gpointer key, gpointer value, gpointer user_data)
 
     if (contents)
     {
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-enum"
+#endif
         switch (id)
         {
             case TAG_DOC_DATECREATED:
@@ -232,6 +243,9 @@ static void process_metadata(gpointer key, gpointer value, gpointer user_data)
             default:
                 break;
         }
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
         g_strdelimit (contents, "\t\n\r", ' ');
         g_strstrip (contents);
@@ -251,7 +265,11 @@ inline void process_opendoc_infile(GsfInfile *infile, GnomeCmdFileMetadata *meta
         return;
 
     GsfDocMetaData *sections = gsf_doc_meta_data_new ();
+#ifdef HAVE_GSF_1_14_24
+    GError         *err = gsf_doc_meta_data_read_from_odf (sections, meta_file);
+#else
     GError         *err = gsf_opendoc_metadata_read (meta_file, sections);
+#endif
 
     if (!err)
         gsf_doc_meta_data_foreach (sections, &process_metadata, metadata);
@@ -265,7 +283,11 @@ inline void process_opendoc_infile(GsfInfile *infile, GnomeCmdFileMetadata *meta
 inline void process_msole_summary(GsfInput *input, GnomeCmdFileMetadata *metadata)
 {
     GsfDocMetaData *sections = gsf_doc_meta_data_new ();
+#ifdef HAVE_GSF_1_14_24
+    GError         *err = gsf_doc_meta_data_read_from_odf (sections, input);
+#else
     GError         *err = gsf_msole_metadata_read (input, sections);
+#endif
 
     if (!err)
         gsf_doc_meta_data_foreach (sections, &process_metadata, metadata);

--- a/src/tags/gnome-cmd-tags-exiv2.cc
+++ b/src/tags/gnome-cmd-tags-exiv2.cc
@@ -58,6 +58,10 @@ inline void readTags(GnomeCmdFileMetadata *metadata, const T &data)
 
         DEBUG('t', "\t%s (%s) = %s\n", i->key().c_str(), gcmd_tags_get_name(tag), i->toString().c_str());
 
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-enum"
+#endif
         switch (tag)
         {
             case TAG_NONE:
@@ -101,6 +105,9 @@ inline void readTags(GnomeCmdFileMetadata *metadata, const T &data)
                 break;
         }
     }
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 }
 #endif
 

--- a/src/tags/gnome-cmd-tags-poppler.cc
+++ b/src/tags/gnome-cmd-tags-poppler.cc
@@ -36,12 +36,16 @@ using namespace std;
 
 #ifdef HAVE_PDF
 
-gchar * pgd_format_date (time_t utime)
+static gchar * pgd_format_date (time_t utime)
 {
 	time_t time = (time_t) utime;
         char s[256];
         const char *fmt_hack = "%c";
         size_t len;
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
 #ifdef HAVE_LOCALTIME_R
         struct tm t;
         if (time == 0 || !localtime_r (&time, &t)) return NULL;
@@ -50,6 +54,9 @@ gchar * pgd_format_date (time_t utime)
         struct tm *t;
         if (time == 0 || !(t = localtime (&time)) ) return NULL;
         len = strftime (s, sizeof (s), fmt_hack, t);
+#endif
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
 #endif
 	
         if (len == 0 || s[0] == '\0') return NULL;
@@ -185,7 +192,11 @@ inline gchar *paper_name (gdouble doc_width, double doc_height)
 #endif
 
 
-void gcmd_tags_poppler_load_metadata(GnomeCmdFile *f)
+static void gcmd_tags_poppler_load_metadata(GnomeCmdFile *f)
+#ifdef __GNUC__
+__attribute__((unused));
+#endif
+static void gcmd_tags_poppler_load_metadata(GnomeCmdFile *f)
 {
     g_return_if_fail (f != NULL);
     g_return_if_fail (f->info != NULL);


### PR DESCRIPTION
Error fix part 1:

src/dialogs/gnome-cmd-options-dialog.cc:272:58: error: format not a string literal, format string not check
ed [-Werror=format-nonliteral]
 - Just ignore warnings by pragma

src/dialogs/gnome-cmd-search-dialog.cc:1023:24: error: this statement may fall through
 - For now, I just ignored this by pragma, but you must review this

src/tags/../dict.h:151:7: error: declaration of 'TUPLE' shadows a previous local [-Werror=shadow]
 - Don't know well, however I removed this warning by not using typedef.

src/tags/gnome-cmd-tags-doc.cc:207:16: error: enumeration value 'TAG_NONE' not handled in switch [-Werror=s
witch-enum]
  - Just ignore warnings by pragma

src/tags/gnome-cmd-tags-doc.cc:254:73: error: 'GError* gsf_opendoc_metadata_read(GsfInput*, GsfDocMetaData*
)' is deprecated: Use 'gsf_doc_meta_data_read_from_odf' instead [-Werror=deprecated-declarations]
  - Use modern function, add check in configure.ac

src/tags/gnome-cmd-tags-doc.cc:268:67: error: 'GError* gsf_msole_metadata_read(GsfInput*, GsfDocMetaData*)'
 is deprecated: Use 'gsf_doc_meta_data_read_from_msole' instead [-Werror=deprecated-declarations]
  - Same above

src/tags/gnome-cmd-tags-exiv2.cc:61:9: error: enumeration value 'TAG_AUDIO_ALBUMARTIST' not handled in switch [-Werror=switch-enum]
  - Same above

src/tags/gnome-cmd-tags-poppler.cc:39:9: error: no previous declaration for 'gchar* pgd_format_date(time_t)' [-Werror=missing-declarations]
  - Change function to "static" (global function needs previous declaration if it is not static)

src/tags/gnome-cmd-tags-poppler.cc:52:51: error: format not a string literal, format string not checked [-Werror=format-nonliteral]
  - Same above, just ignore this by pragma

src/tags/gnome-cmd-tags-poppler.cc:188:6: error: no previous declaration for 'void gcmd_tags_poppler_load_metadata(GnomeCmdFile*)' [-Werror=missing-declarations]
  - Change function to "static", but note that it seems this function is not used anymore.