### PR TITLE
Fix compilation error part 2

### DIFF
--- a/src/dialogs/gnome-cmd-search-dialog.cc
+++ b/src/dialogs/gnome-cmd-search-dialog.cc
@@ -1023,6 +1023,9 @@ void GnomeCmdSearchDialog::Private::on_dialog_response(GtkDialog *window, int re
                 g_free (dpath);
             }
 
+#if defined (__GNUC__) && __GNUC__ >= 7
+        __attribute__ ((fallthrough));
+#endif
         case GTK_RESPONSE_NONE:
         case GTK_RESPONSE_DELETE_EVENT:
         case GTK_RESPONSE_CANCEL:

--- a/src/intviewer/bm_chartype.cc
+++ b/src/intviewer/bm_chartype.cc
@@ -49,7 +49,7 @@ inline void bch_free(GHashTable *bch)
 
 static void bch_set_value(GHashTable *bch, int key, int value)
 {
-    g_hash_table_insert (bch, (gpointer) key, (gpointer) value);
+    g_hash_table_insert (bch, GINT_TO_POINTER(key), GINT_TO_POINTER(value));
 }
 
 

--- a/src/intviewer/datapresentation.cc
+++ b/src/intviewer/datapresentation.cc
@@ -123,6 +123,9 @@ void gv_set_data_presentation_mode(GVDataPresentation *dp, PRESENTATION present)
             dp->scroll_lines = binfixed_scroll_lines;
             dp->get_end_of_line_offset = binfixed_get_eol;
             break;
+
+        default:
+            break;
     }
 }
 

--- a/src/intviewer/fileops.cc
+++ b/src/intviewer/fileops.cc
@@ -236,10 +236,17 @@ const char *gv_file_load(ViewerFileOps *ops, int fd)
         return gv_file_init_growing_view (ops, ops->filename);
     }
 #ifdef HAVE_MMAP
+ #if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
     if ((size_t) ops->s.st_size == ops->s.st_size)
         ops->data = (unsigned char *) mmap (0, ops->s.st_size, PROT_READ, MAP_FILE | MAP_SHARED, ops->file, 0);
     else
         ops->data = (unsigned char *) MAP_FAILED;
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     if (ops->data != MAP_FAILED)
     {
@@ -256,10 +263,17 @@ const char *gv_file_load(ViewerFileOps *ops, int fd)
     * for any reason, so we use this as fallback (pavel@ucw.cz) */
 
     // Make sure view->s.st_size is not truncated when passed to g_malloc
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
     if ((gulong) ops->s.st_size == ops->s.st_size)
         ops->data = (unsigned char *) g_try_malloc ((gulong) ops->s.st_size);
     else
         ops->data = NULL;
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     if (ops->data == NULL ||
         lseek (ops->file, 0, SEEK_SET) != 0 ||
@@ -305,12 +319,19 @@ int gv_file_get_byte (ViewerFileOps *ops, offset_type byte_index)
          */
                 if (n != -1)
                     ops->bytes_read += n;
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
                 if (ops->s.st_size < ops->bytes_read)
                 {
                     ops->bottom_first = INVALID_OFFSET; // Invalidate cache
                     ops->s.st_size = ops->bytes_read;
                     ops->last_byte = ops->bytes_read;
                 }
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             }
             ops->blocks = page;
         }

--- a/src/intviewer/image-render.cc
+++ b/src/intviewer/image-render.cc
@@ -826,7 +826,11 @@ inline void image_render_start_background_pixbuf_loading (ImageRender *obj)
 
     // Start background loading
     g_object_ref (obj);
+#if GLIB_CHECK_VERSION(2, 32, 0)
+    obj->priv->pixbuf_loading_thread = g_thread_new("pixbuf_load", (GThreadFunc) image_render_pixbuf_loading_thread, (gpointer) obj);
+#else
     obj->priv->pixbuf_loading_thread = g_thread_create((GThreadFunc) image_render_pixbuf_loading_thread, (gpointer) obj, FALSE, NULL);
+#endif
 }
 
 

--- a/src/intviewer/inputmodes.cc
+++ b/src/intviewer/inputmodes.cc
@@ -390,7 +390,7 @@ inline gboolean utf8_is_valid_char(GVInputModesData *imd, offset_type offset)
 {
     int len = utf8_get_char_len(imd, offset);
 
-    if (len==0 || (gv_input_mode_get_byte(imd, offset+len)==INVALID_CHAR))
+    if (len==0 || (gv_input_mode_get_byte(imd, offset+len)==(int)INVALID_CHAR))
         return FALSE;
 
     if (len==1)

--- a/src/intviewer/search-dlg.cc
+++ b/src/intviewer/search-dlg.cc
@@ -122,7 +122,7 @@ inline void set_text_mode (GViewerSearchDlg *sdlg)
 
 static void set_hex_mode (GViewerSearchDlg *sdlg)
 {
-#if HEX_HISTORY
+#if defined(HEX_HISTORY)
     for (GList *i=gnome_cmd_data.intviewer_defaults.hex_patterns.ents; i; i=i->next)
         if (i->data)
             gtk_combo_box_prepend_text (GTK_COMBO_BOX (sdlg->priv->entry), (gchar *) i->data);

--- a/src/intviewer/search-progress-dlg.cc
+++ b/src/intviewer/search-progress-dlg.cc
@@ -135,7 +135,7 @@ GType gviewer_search_progress_dlg_get_type ()
 }
 
 
-GtkWidget *gviewer_search_progress_dlg_new (GtkWindow *parent)
+static GtkWidget *gviewer_search_progress_dlg_new (GtkWindow *parent)
 {
     GViewerSearchProgressDlg *dlg = (GViewerSearchProgressDlg *) g_object_new (gviewer_search_progress_dlg_get_type(), NULL);
 
@@ -143,7 +143,7 @@ GtkWidget *gviewer_search_progress_dlg_new (GtkWindow *parent)
 }
 
 
-gboolean search_progress_dlg_timeout(gpointer data)
+static gboolean search_progress_dlg_timeout(gpointer data)
 {
     g_return_val_if_fail (IS_GVIEWER_SEARCH_PROGRESS_DLG (data), FALSE);
 

--- a/src/tags/gnome-cmd-tags-exiv2.cc
+++ b/src/tags/gnome-cmd-tags-exiv2.cc
@@ -68,7 +68,7 @@ inline void readTags(GnomeCmdFileMetadata *metadata, const T &data)
                 break;
 
             case TAG_EXIF_MAKERNOTE:
-                metadata->addf(tag,_("unsupported tag (suppressed %u B of binary data)"), i->size());
+                metadata->addf(tag,_("unsupported tag (suppressed %ld B of binary data)"), i->size());
                 break;
 
             case TAG_EXIF_EXIFVERSION:

--- a/src/tags/gnome-cmd-tags-taglib.cc
+++ b/src/tags/gnome-cmd-tags-taglib.cc
@@ -24,6 +24,7 @@
 
 #include "gnome-cmd-includes.h"
 #include "gnome-cmd-tags.h"
+#include "gnome-cmd-tags-taglib.h"
 #include "utils.h"
 #include "dict.h"
 
@@ -91,7 +92,11 @@ inline bool getAudioProperties(GnomeCmdFileMetadata &metadata, const TagLib::Aud
             N_("Reserved")
         };
 
-        static const gchar *emphasis_names[] =
+        static const gchar *emphasis_names[]
+#ifdef __GNUC__
+        __attribute__ ((unused))
+#endif
+        =
         {
             N_("None"),
             N_("10-15ms"),
@@ -163,7 +168,7 @@ inline bool getAudioProperties(GnomeCmdFileMetadata &metadata, const TagLib::Aud
 }
 
 
-inline void readTags(GnomeCmdFileMetadata &metadata, const TagLib::ID3v2::Tag *id3v2Tag)
+static void readTags(GnomeCmdFileMetadata &metadata, const TagLib::ID3v2::Tag *id3v2Tag)
 {
     if (!id3v2Tag)
         return;
@@ -177,6 +182,10 @@ inline void readTags(GnomeCmdFileMetadata &metadata, const TagLib::ID3v2::Tag *i
 
         string val;
 
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-enum"
+#endif
         switch (tag)
         {
             case TAG_NONE:
@@ -228,6 +237,9 @@ inline void readTags(GnomeCmdFileMetadata &metadata, const TagLib::ID3v2::Tag *i
             default:
                 break;
         }
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
         metadata.add(tag,val);
         DEBUG('t', "\t%s (%s) = %s\n", id.c_str(), gcmd_tags_get_name(tag), val.c_str());
@@ -246,6 +258,10 @@ inline bool readTags(GnomeCmdFileMetadata &metadata, const TagLib::Ogg::XiphComm
 
         string val;
 
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-enum"
+#endif
         switch (tag)
         {
             case TAG_NONE:
@@ -255,6 +271,10 @@ inline bool readTags(GnomeCmdFileMetadata &metadata, const TagLib::Ogg::XiphComm
                 val = i->second.toString().to8Bit(true);
                 break;
         }
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch-enum"
+#endif
 
         metadata.add(tag,val);
         DEBUG('t', "\t%s (%s) = %s\n", id.c_str(), gcmd_tags_get_name(tag), val.c_str());
@@ -264,7 +284,7 @@ inline bool readTags(GnomeCmdFileMetadata &metadata, const TagLib::Ogg::XiphComm
 }
 
 
-inline bool getTag(GnomeCmdFileMetadata &metadata, TagLib::File *file, const TagLib::Tag *tag)
+static bool getTag(GnomeCmdFileMetadata &metadata, TagLib::File *file, const TagLib::Tag *tag)
 {
     if (!tag || tag->isEmpty())
         return false;
@@ -396,7 +416,7 @@ void gcmd_tags_taglib_init()
     static struct
     {
         GnomeCmdTag tag;
-        gchar *name;
+        const gchar *name;
     }
     ogg_data[] = {
                   {TAG_AUDIO_COMMENT,"COMMENT"},

--- a/src/tags/gnome-cmd-tags.h
+++ b/src/tags/gnome-cmd-tags.h
@@ -565,7 +565,7 @@ inline gboolean GnomeCmdFileMetadata::is_accessed (const GnomeCmdTagClass tag_cl
 }
 
 
-inline void GnomeCmdFileMetadata::add (const GnomeCmdTag tag, std::string value)
+void GnomeCmdFileMetadata::add (const GnomeCmdTag tag, std::string value)
 {
     if (value.empty())
         return;


### PR DESCRIPTION
src/dialogs/gnome-cmd-search-dialog.cc:1023:24: error: this statement may fall through [-Werror=implicit-fallthrough=]
  - gcc7 new waring. Just disabled with pragma, but you must review this (whether fallthrough here is actually intended or not)

src/tags/gnome-cmd-tags-exiv2.cc:71:17: error: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'long int'
src/tags/gnome-cmd-tags-exiv2.cc:71:17: error: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'long int' [-Werror=format=]
  - Should use %ld

src/tags/gnome-cmd-tags-taglib.cc:94:29: error: unused variable 'emphasis_names' [-Werror=unused-variable]
  - This variable is in the comment. For now, disabled warning with pragma

rc/tags/gnome-cmd-tags-taglib.cc:180:16: error: enumeration value 'TAG_AUDIO_ALBUMARTIST' not handled in switch [-Werror=switch-enum]
  - Nuked warning with pragma

src/tags/gnome-cmd-tags-taglib.cc:307:6: error: no previous declaration for 'void gcmd_tags_taglib_init()
  - Add needed header

src/tags/gnome-cmd-tags-taglib.cc:412:18: error: ISO C++ forbids converting a string constant to 'gchar* {
aka char*}'
  - Change struct member to "const gchar *"

src/tags/gnome-cmd-tags-taglib.cc:166:13: error: inlining failed in call to 'void readTags(GnomeCmdFileMetadata&, const TagLib::ID3v2::Tag*)': --param max-inline-insns-single limit reached [-Werror=inline]
src/tags/gnome-cmd-tags-taglib.cc:166:13: error: inlining failed in call to 'void readTags(GnomeCmdFileMetadata&, const TagLib::ID3v2::Tag*)': --param max-inline-insns-single limit reached [-Werror=inline]
  - Function size too long, killed inline

src/intviewer/bm_chartype.cc:52:42: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
  - Use GINT_TO_POINTER

src/intviewer/datapresentation.cc:107:12: error: switch missing default case [-Werror=switch-default]
  - easy fix

src/intviewer/fileops.cc:239:33: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
src/intviewer/fileops.cc:259:33: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
src/intviewer/fileops.cc:308:36: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
  - Just ignored this for now by pragma. "Fixing" this can make more mistakes.

src/intviewer/image-render.cc:829:133: error: 'GThread* g_thread_create(GThreadFunc, gpointer, gboolean, GError**)' is deprecated: Use 'g_thread_new' instead [-Werror=deprecated-declarations]
  - Newly written code should use g_thread_new. Please review this.

src/intviewer/inputmodes.cc:393:59: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
  - Cast INVALID_CHAR with int

src/intviewer/search-dlg.cc:125:5: error: "HEX_HISTORY" is not defined, evaluates to 0 [-Werror=undef]
 #if HEX_HISTORY
  - Change to ifdef

src/intviewer/search-progress-dlg.cc:138:12: error: no previous declaration for 'GtkWidget* gviewer_search_progress_dlg_new(GtkWindow*)' [-Werror=missing-declarations]
  - Change to static