### PR TITLE
fix warning: unused variable

### DIFF
--- a/src/tags/gnome-cmd-tags.cc
+++ b/src/tags/gnome-cmd-tags.cc
@@ -69,7 +69,9 @@ static char no_support_for_taglib_tags_string[] = N_("<ID3, APE, FLAC and Vorbis
 #endif
 
 #ifndef HAVE_GSF
+#ifndef HAVE_PDF
 static char no_support_for_libgsf_tags_string[] = N_("<OLE2 and ODF tags not supported>");
+#endif
 #endif
 
 #ifndef HAVE_PDF


### PR DESCRIPTION
gnome-cmd-tags.cc:72:13: error: 'no_support_for_libgsf_tags_string' defined but not used [-Werror=unused-variable]
 static char no_support_for_libgsf_tags_string[] = N_("<OLE2 and ODF tags not supported>");
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Problem introduced in:

commit d2b2782b76b6842f9684322e7fd45cf738bd9907
"Properly report unsuported Doc.* tags"