### PR TITLE
Fix compilation errors part 8

### DIFF
--- a/plugins/fileroller/file-roller-plugin.cc
+++ b/plugins/fileroller/file-roller-plugin.cc
@@ -349,7 +349,14 @@ static void on_add_to_archive (GtkMenuItem *item, FileRollerPlugin *plugin)
         char s[256];
         time_t t = time (NULL);
 
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
         strftime (s, sizeof(s), locale_format, localtime (&t));
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
         g_free (locale_format);
         gchar *file_prefix = g_locale_to_utf8 (s, -1, NULL, NULL, NULL);
 
@@ -517,7 +524,14 @@ static void on_date_format_update (GtkEditable *editable, GtkWidget *options_dia
     char s[256];
     time_t t = time (NULL);
 
+#if defined (__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
     strftime (s, sizeof(s), locale_format, localtime (&t));
+#if defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     gchar *file_prefix = g_locale_to_utf8 (s, -1, NULL, NULL, NULL);
     gchar *filename_tmp = g_strdup_printf("%s%s", file_prefix, file_suffix);
     gchar *replacement = g_strdup(_("File"));


### PR DESCRIPTION
Perhaps gcc7 is more strict than gcc4.8 .

```
plugins/fileroller/file-roller-plugin.cc:352:62: error: format not a string literal, format string not checked [-Werror=format-nonliteral]
         strftime (s, sizeof(s), locale_format, localtime (&t));

plugins/fileroller/file-roller-plugin.cc:520:58: error: format not a string literal, format string not checked [-Werror=format-nonliteral]

Ignore these warnings.
```