### PR TITLE
Compilation fix part 8: fix for 32bit

### DIFF
--- a/src/utils.cc
+++ b/src/utils.cc
@@ -377,13 +377,13 @@ const gchar *size2string (GnomeVFSFileSize size, GnomeCmdSizeDispMode size_disp_
                 if (i)
                     g_snprintf (buf0, sizeof(buf0), "%.1f %s ", dsize, prefixes[i]);
                 else
-                    g_snprintf (buf0, sizeof(buf0), "%lu %s ", size, prefixes[0]);
+                    g_snprintf (buf0, sizeof(buf0), "%" GNOME_VFS_SIZE_FORMAT_STR " %s ", size, prefixes[0]);
             }
             break;
 
         case GNOME_CMD_SIZE_DISP_MODE_GROUPED:
             {
-                gint len = g_snprintf (buf0, sizeof(buf0), "%lu ", size);
+                gint len = g_snprintf (buf0, sizeof(buf0), "%" GNOME_VFS_SIZE_FORMAT_STR " ", size);
 
                 if (len < 5)
                     return buf0;
@@ -406,11 +406,11 @@ const gchar *size2string (GnomeVFSFileSize size, GnomeCmdSizeDispMode size_disp_
             return buf1;
 
         case GNOME_CMD_SIZE_DISP_MODE_LOCALE:
-            g_snprintf (buf0, sizeof(buf0), "%'lu ", size);
+            g_snprintf (buf0, sizeof(buf0), "%'" GNOME_VFS_SIZE_FORMAT_STR " ", size);
             break;
 
         case GNOME_CMD_SIZE_DISP_MODE_PLAIN:
-            g_snprintf (buf0, sizeof(buf0), "%lu ", size);
+            g_snprintf (buf0, sizeof(buf0), "%" GNOME_VFS_SIZE_FORMAT_STR " ", size);
             break;
 
         default:


### PR DESCRIPTION
After 4fdbe339c7ace2a6161afa8de9841d9cb5912aa1 ,
now on 32bit (e.g. i686, armv7hl) the following errors are raised:

src/utils.cc:380:81: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'GnomeVFSFileSize {aka long long unsigned int}' [-Werror=format=]
                     g_snprintf (buf0, sizeof(buf0), "%lu %s ", size, prefixes[0]);
src/utils.cc:386:72: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'GnomeVFSFileSize {aka long long unsigned int}' [-Werror=format=]
                 gint len = g_snprintf (buf0, sizeof(buf0), "%lu ", size);
src/utils.cc:409:58: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'GnomeVFSFileSize {aka long long unsigned int}' [-Werror=format=]
             g_snprintf (buf0, sizeof(buf0), "%'lu ", size);
src/utils.cc:413:57: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'GnomeVFSFileSize {aka long long unsigned int}' [-Werror=format=]
             g_snprintf (buf0, sizeof(buf0), "%lu ", size);

size has GnomeVFSFileSize, which is unsigned long on 64bit (so %lu is okay),
however on 32bit it is unsigned long long, so it should be %llu.

Thankfully, there is a defined macro 'GNOME_VFS_SIZE_FORMAT_STR', so use this.